### PR TITLE
Change 'use script' to 'use strict'

### DIFF
--- a/bin/aws-s3-upload.js
+++ b/bin/aws-s3-upload.js
@@ -1,4 +1,4 @@
-'use script'
+'use strict'
 
 const s3Upload = require('../lib/s3Upload')
 const mime = require('mime-types')

--- a/lib/s3Upload.js
+++ b/lib/s3Upload.js
@@ -1,4 +1,4 @@
-'use script'
+'use strict'
 
 require('dotenv').config()
 


### PR DESCRIPTION
Change 'use script' to 'use strict' in aws-s3-upload and s3upload