### PR TITLE
Remove console.error in POST method

### DIFF
--- a/app/routes/upload_routes.js
+++ b/app/routes/upload_routes.js
@@ -87,7 +87,7 @@ router.post('/uploads', requireToken, multerUpload.single('upload[file]'), (req,
     .then(upload => {
       res.status(201).json({ upload: upload.toObject() })
     })
-    .catch(console.error)
+    .catch(err => handle(err, res))
   // Upload.create(req.body.upload)
   //   // respond to succesful `create` with status 201 and JSON of new "upload"
   //   .then(upload => {


### PR DESCRIPTION
- Replace .catch(console.error) with .catch(err => handle(err, res))
- Console.error is still used in bin/aws-s3-upload.js,
  lib/error_handler.js, test/exmaple.js